### PR TITLE
Mapping repeater feature, workaround for hiding joysticks when mapping in games.

### DIFF
--- a/StaticLibs/INCLUDES/UjpsCore/AbstractProfile.h
+++ b/StaticLibs/INCLUDES/UjpsCore/AbstractProfile.h
@@ -12,6 +12,7 @@
 #include "LAYERS/LayerCalculator.h"
 #include "VirtualEventsQueue.h"
 #include "AxisDirection.h"
+#include "ujpscore-global.h"
 
 class RealJoysticksManager;
 class AbstractRealJoystick;
@@ -23,7 +24,7 @@ class AbstractTrigger;
 class AbstractAction;
 
 
-class AbstractProfile : public QObject
+class UJPSCORE_EXPORT AbstractProfile : public QObject
 {
 	Q_OBJECT
 	
@@ -42,7 +43,10 @@ class AbstractProfile : public QObject
 		
 		uint ms2cycles(uint msecs) const;
 		void setTimeStep(int dtms);			// useful to count the number of cycles for pulses and delays
+		int getTimeStep();
 		
+		void setMappingRepeater(bool enable);
+		bool isMappingRepeater();
 		
 	signals:
 		void message(const QString &str, QColor color);
@@ -96,6 +100,7 @@ class AbstractProfile : public QObject
 		
 		int m_dtms;
 		bool m_bFirstStep;
+		bool m_bMappingRepeaterEnabled;
 		
 		RealJoysticksManager *m_rjm;
 		LayerCalculator m_layerCalculator;

--- a/StaticLibs/INCLUDES/UjpsCore/AbstractProfile.h
+++ b/StaticLibs/INCLUDES/UjpsCore/AbstractProfile.h
@@ -12,7 +12,6 @@
 #include "LAYERS/LayerCalculator.h"
 #include "VirtualEventsQueue.h"
 #include "AxisDirection.h"
-#include "ujpscore-global.h"
 
 class RealJoysticksManager;
 class AbstractRealJoystick;
@@ -24,7 +23,7 @@ class AbstractTrigger;
 class AbstractAction;
 
 
-class UJPSCORE_EXPORT AbstractProfile : public QObject
+class AbstractProfile : public QObject
 {
 	Q_OBJECT
 	

--- a/StaticLibs/INCLUDES/UjpsCore/VirtualEventsQueue.h
+++ b/StaticLibs/INCLUDES/UjpsCore/VirtualEventsQueue.h
@@ -3,12 +3,16 @@
 
 
 #include <QVector>
+#include <QTimer>
 #include "VirtualEvent.h"
+#include "ujpscore-global.h"
 
-class VirtualEventsQueue
+class AbstractProfile;
+
+class UJPSCORE_EXPORT VirtualEventsQueue
 {
 	public:
-		VirtualEventsQueue() = default;
+		VirtualEventsQueue(AbstractProfile &profileRef);
 		VirtualEventsQueue(const VirtualEventsQueue &other) = delete;
 		VirtualEventsQueue(VirtualEventsQueue &&other) = delete;
 		VirtualEventsQueue& operator=(const VirtualEventsQueue &other) = delete;
@@ -19,9 +23,18 @@ class VirtualEventsQueue
 		void postEvents(const QVector<VirtualEvent> &events);
 		void processEvents();
 		
-		
 	private:
+		void setMappingRepeaterEvent(const VirtualEvent &event);
+		void updateMappingRepeaterEvent();
+
+		AbstractProfile &m_profileRef;
+
 		QVector<VirtualEvent> m_events;
+
+		VirtualEvent m_repeaterEvent;
+		float m_repeaterOriginalAxisValue;
+		int m_repeaterDtms;
+		int m_repeaterDtmsTotal;
 };
 
 

--- a/StaticLibs/INCLUDES/UjpsCore/VirtualEventsQueue.h
+++ b/StaticLibs/INCLUDES/UjpsCore/VirtualEventsQueue.h
@@ -5,11 +5,10 @@
 #include <QVector>
 #include <QTimer>
 #include "VirtualEvent.h"
-#include "ujpscore-global.h"
 
 class AbstractProfile;
 
-class UJPSCORE_EXPORT VirtualEventsQueue
+class VirtualEventsQueue
 {
 	public:
 		VirtualEventsQueue(AbstractProfile &profileRef);

--- a/StaticLibs/INCLUDES/VirtualJoysticks/VirtualEvent.h
+++ b/StaticLibs/INCLUDES/VirtualJoysticks/VirtualEvent.h
@@ -13,6 +13,7 @@ using uint = unsigned int;
 
 enum class EventType
 {
+	Unused,
 	VJoy,
 	Keyboard,
 	Callback

--- a/StaticLibs/INCLUDES/VirtualJoysticks/VirtualJoystick.h
+++ b/StaticLibs/INCLUDES/VirtualJoysticks/VirtualJoystick.h
@@ -9,8 +9,10 @@
 #include "vJoyModifiedInterface/stdafx.h"
 #include "vJoyModifiedInterface/public.h"
 #include "AbsoluteOrRelative.h"
+#include "virtualjoysticks-global.h"
 using uint = unsigned int;
 
+const int g_MAPPING_REPEATER_DURATION = 5; // in seconds
 
 enum class Priority
 {
@@ -26,7 +28,7 @@ enum class TrimOrNot
 };
 
 
-class VirtualJoystick : public QObject
+class VIRTUALJOYSTICKS_EXPORT VirtualJoystick : public QObject
 {
 	Q_OBJECT
 	

--- a/StaticLibs/INCLUDES/VirtualJoysticks/VirtualJoystick.h
+++ b/StaticLibs/INCLUDES/VirtualJoysticks/VirtualJoystick.h
@@ -9,7 +9,6 @@
 #include "vJoyModifiedInterface/stdafx.h"
 #include "vJoyModifiedInterface/public.h"
 #include "AbsoluteOrRelative.h"
-#include "virtualjoysticks-global.h"
 using uint = unsigned int;
 
 const int g_MAPPING_REPEATER_DURATION = 5; // in seconds
@@ -28,7 +27,7 @@ enum class TrimOrNot
 };
 
 
-class VIRTUALJOYSTICKS_EXPORT VirtualJoystick : public QObject
+class VirtualJoystick : public QObject
 {
 	Q_OBJECT
 	

--- a/StaticLibs/SOURCES/UjpsCore/CODE/AbstractProfile.cpp
+++ b/StaticLibs/SOURCES/UjpsCore/CODE/AbstractProfile.cpp
@@ -47,11 +47,12 @@
 
 
 // CONSTRUCTEUR ET DESTRUCTEUR ////////////////////////////////////////////////
-AbstractProfile::AbstractProfile() : QObject()
+AbstractProfile::AbstractProfile() : QObject(), m_eventsQueue(*this)
 {
 	m_isProcessingEvents = false;
 	m_dtms = 15;
 	m_bFirstStep = true;
+	m_bMappingRepeaterEnabled = false;
 	
 	m_rjm = new RealJoysticksManager{};
 	QString controllersPluginsDirPath = QCoreApplication::applicationDirPath() + "/../../ControllersPlugins/PLUGINS/";
@@ -231,6 +232,21 @@ void AbstractProfile::setTimeStep(int dtms)
 {
 	Q_ASSERT(dtms > 0);
 	m_dtms = dtms;
+}
+
+int AbstractProfile::getTimeStep()
+{
+	return m_dtms;
+}
+
+void AbstractProfile::setMappingRepeater(bool enable)
+{
+	m_bMappingRepeaterEnabled = enable;
+}
+
+bool AbstractProfile::isMappingRepeater()
+{
+	return m_bMappingRepeaterEnabled;
 }
 
 // MS 2 CYCLES ////////////////////////////////////////////////////////////////

--- a/UjpsMainApp/CODE/HMI/MainWindow.cpp
+++ b/UjpsMainApp/CODE/HMI/MainWindow.cpp
@@ -48,44 +48,44 @@ MainWindow::MainWindow(QString proFilePath, int dtms, bool bPlay, QWidget *paren
 	settings.readFile();
 	bool bUseVJoyConfigBinary = settings.property("bUseVJoyConfigBinary").toBool();
 	QString vJoyConfigBinary = settings.property("vJoyConfigBinary").toString();
-	VirtualJoystick::setVJoyConfigOptions(bUseVJoyConfigBinary, vJoyConfigBinary);
-
+	VirtualJoystick::setVJoyConfigOptions(bUseVJoyConfigBinary,vJoyConfigBinary);
+	
 	// init
 	m_proFilePath = "";
 	m_dllFilePath = "";
 	m_dllFileName = "";
-	m_engine = new ProfileEngine{ this };
-
-	m_compilWidget = new CompilationWidget{ this };
-
+	m_engine = new ProfileEngine{this};
+	
+	m_compilWidget = new CompilationWidget{this};
+	
 	this->createActions();
 	this->setupWidget();
 	this->setState(HmiState::WaitingForDll);
-
+	
 	// connections
 	QObject::connect(chkMappingRepeater, &QCheckBox::stateChanged, m_engine, &ProfileEngine::slotMappingRepeaterChanged);
-	QObject::connect(m_engine, &ProfileEngine::message, textEdit, &TextEdit::addMessage);
-	QObject::connect(actionCompilation, &QAction::triggered, this, &MainWindow::slotCompilation);
-	QObject::connect(actionSettings, &QAction::triggered, this, &MainWindow::slotSettings);
-	QObject::connect(actionPlay, &QAction::triggered, this, &MainWindow::slotPlay);
-	QObject::connect(actionStop, &QAction::triggered, this, &MainWindow::slotStop);
-	QObject::connect(actionUnload, &QAction::triggered, this, &MainWindow::slotUnload);
-	QObject::connect(boutonBrowse, &QPushButton::clicked, this, &MainWindow::slotBrowseButtonClicked);
-
+	QObject::connect(m_engine,&ProfileEngine::message,textEdit,&TextEdit::addMessage);
+	QObject::connect(actionCompilation,&QAction::triggered,this,&MainWindow::slotCompilation);
+	QObject::connect(actionSettings,&QAction::triggered,this,&MainWindow::slotSettings);
+	QObject::connect(actionPlay,&QAction::triggered,this,&MainWindow::slotPlay);
+	QObject::connect(actionStop,&QAction::triggered,this,&MainWindow::slotStop);
+	QObject::connect(actionUnload,&QAction::triggered,this,&MainWindow::slotUnload);
+	QObject::connect(boutonBrowse,&QPushButton::clicked,this,&MainWindow::slotBrowseButtonClicked);
+	
 	// arguments supplémentaires
-	if(!proFilePath.isEmpty())
+	if (!proFilePath.isEmpty())
 	{
 		m_proFilePath = proFilePath;
 		m_dllFilePath = "";
 		m_dllFileName = "";
-
+		
 		lineDllPath->setText(m_proFilePath);
-		textEdit->addMessage("Plugin path changed for " + m_proFilePath, Qt::black);
+		textEdit->addMessage("Plugin path changed for " + m_proFilePath,Qt::black);
 		this->setState(HmiState::ReadyToPlayNotLoaded);
-
+		
 		boxRefreshRate->setValue(dtms);
-
-		if(bPlay) { this->slotPlay(); }
+		
+		if (bPlay) {this->slotPlay();}
 	}
 }
 
@@ -93,7 +93,7 @@ MainWindow::~MainWindow()
 {
 	// write settings
 	ApplicationSettings& settings = ApplicationSettings::instance();
-	if(!settings.isEmpty()) { settings.writeFile(); }
+	if (!settings.isEmpty()) {settings.writeFile();}
 }
 
 
@@ -103,23 +103,23 @@ MainWindow::~MainWindow()
 // CREATE ACTIONS /////////////////////////////////////////////////////////////
 void MainWindow::createActions()
 {
-	actionSettings = new QAction("Settings", this);
+	actionSettings = new QAction("Settings",this);
 	actionSettings->setStatusTip("Application settings");
 	actionSettings->setIcon(QIcon(":/RESOURCES/ICONES/outils.png"));
-
-	actionCompilation = new QAction("Compilation", this);
+	
+	actionCompilation = new QAction("Compilation",this);
 	actionCompilation->setStatusTip("Compile profile");
 	actionCompilation->setIcon(QIcon(":/RESOURCES/ICONES/compilation.png"));
-
-	actionPlay = new QAction("Run", this);
+	
+	actionPlay = new QAction("Run",this);
 	actionPlay->setStatusTip("Load and run profile");
 	actionPlay->setIcon(QIcon(":/RESOURCES/ICONES/play.png"));
-
-	actionStop = new QAction("Stop", this);
+	
+	actionStop = new QAction("Stop",this);
 	actionStop->setStatusTip("Stop profile");
 	actionStop->setIcon(QIcon(":/RESOURCES/ICONES/stop.png"));
-
-	actionUnload = new QAction("Unload", this);
+	
+	actionUnload = new QAction("Unload",this);
 	actionUnload->setStatusTip("Unload profile");
 	actionUnload->setIcon(QIcon(":/RESOURCES/ICONES/eject.png"));
 }
@@ -132,9 +132,9 @@ void MainWindow::setupWidget()
 	this->setLayout(layout);
 	layoutDllChoice = new QHBoxLayout(this);
 	layoutRefreshRate = new QHBoxLayout(this);
-
+	
 	// toolbar
-	toolbar = new QToolBar("Session", this);
+	toolbar = new QToolBar("Session",this);
 	toolbar->setFloatable(false);
 	toolbar->setMovable(false);
 	toolbar->addAction(actionSettings);
@@ -142,30 +142,30 @@ void MainWindow::setupWidget()
 	toolbar->addAction(actionPlay);
 	toolbar->addAction(actionStop);
 	toolbar->addAction(actionUnload);
-
+	
 	// dll choice
-	boutonBrowse = new QPushButton("Browse", this);
+	boutonBrowse = new QPushButton("Browse",this);
 	lineDllPath = new QLineEdit(this);
 	lineDllPath->setReadOnly(true);
-
+	
 	// refresh rate
-	labelRefreshRate = new QLabel("Refresh rate:", this);
+	labelRefreshRate = new QLabel("Refresh rate:",this);
 	boxRefreshRate = new QSpinBox(this);
 	boxRefreshRate->setMinimum(5);
 	boxRefreshRate->setMaximum(500);
 	boxRefreshRate->setValue(15);
 	boxRefreshRate->setSingleStep(500);
 	boxRefreshRate->setSuffix(" ms");
-
+	
 	// mapping repeater
 	chkMappingRepeater = new QCheckBox("Mapping Repeater", this);
 	chkMappingRepeater->setChecked(Qt::CheckState::Unchecked);
 	chkMappingRepeater->setToolTip("Detected vJoy inputs are repeated for " + QString::number(g_MAPPING_REPEATER_DURATION) + " seconds, to help map actions in game without real joysticks interfering.");
 	chkMappingRepeater->setEnabled(false);
-
+	
 	// text edit
 	textEdit = new TextEdit(this);
-
+	
 	// add widgets to laytouts
 	layoutDllChoice->addWidget(boutonBrowse);
 	layoutDllChoice->addWidget(lineDllPath);
@@ -173,23 +173,23 @@ void MainWindow::setupWidget()
 	layoutRefreshRate->addWidget(boxRefreshRate);
 	layoutRefreshRate->addWidget(chkMappingRepeater);
 	layoutRefreshRate->addStretch();
-
+	
 	layout->addLayout(layoutDllChoice);
 	layout->addSpacing(5);
 	layout->addLayout(layoutRefreshRate);
 	layout->addSpacing(5);
 	layout->addWidget(toolbar);
 	layout->addWidget(textEdit);
-
+	
 	// end
-	this->resize(500, 500);
+	this->resize(500,500);
 	this->setWindowIcon(QIcon(":/RESOURCES/ICONES/gamepad.png"));
 }
 
 // SET STATE //////////////////////////////////////////////////////////////////
 void MainWindow::setState(HmiState s)
 {
-	if(s == HmiState::WaitingForDll)
+	if (s == HmiState::WaitingForDll)
 	{
 		actionSettings->setEnabled(true);
 		actionCompilation->setEnabled(false);
@@ -201,7 +201,7 @@ void MainWindow::setState(HmiState s)
 		chkMappingRepeater->setChecked(false);
 		chkMappingRepeater->setEnabled(false);
 	}
-	else if(s == HmiState::ReadyToPlayNotLoaded)
+	else if (s == HmiState::ReadyToPlayNotLoaded)
 	{
 		actionSettings->setEnabled(true);
 		actionCompilation->setEnabled(true);
@@ -213,7 +213,7 @@ void MainWindow::setState(HmiState s)
 		chkMappingRepeater->setChecked(false);
 		chkMappingRepeater->setEnabled(false);
 	}
-	else if(s == HmiState::ReadyToPlayLoaded)
+	else if (s == HmiState::ReadyToPlayLoaded)
 	{
 		actionSettings->setEnabled(false);
 		actionCompilation->setEnabled(false);
@@ -225,7 +225,7 @@ void MainWindow::setState(HmiState s)
 		chkMappingRepeater->setChecked(false);
 		chkMappingRepeater->setEnabled(false);
 	}
-	else if(s == HmiState::Playing)
+	else if (s == HmiState::Playing)
 	{
 		actionSettings->setEnabled(false);
 		actionCompilation->setEnabled(false);
@@ -236,7 +236,7 @@ void MainWindow::setState(HmiState s)
 		boxRefreshRate->setEnabled(false);
 		chkMappingRepeater->setEnabled(true);
 	}
-	else if(s == HmiState::Quitting)
+	else if (s == HmiState::Quitting)
 	{
 		actionSettings->setEnabled(false);
 		actionCompilation->setEnabled(false);
@@ -252,18 +252,20 @@ void MainWindow::setState(HmiState s)
 // CLOSE EVENT ////////////////////////////////////////////////////////////////
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-	textEdit->addMessage("Closing", Qt::black);
+	textEdit->addMessage("Closing",Qt::black);
 	m_engine->stop();
 	this->setState(HmiState::Quitting);
-
-	if(m_engine->isLoaded())
+	
+	if (m_engine->isLoaded())
 	{
 		m_engine->unloadProfile();
 		QThread::sleep(1);
 	}
-
+	
 	event->accept();
 }
+
+
 
 
 
@@ -277,15 +279,15 @@ void MainWindow::closeEvent(QCloseEvent *event)
 void MainWindow::slotBrowseButtonClicked()
 {
 	QString proFilePath = MyFileDialog::getOpenFileName(this, "Select profile plugin", "defaultDirectory", "*.pro");
-	if(proFilePath == "" || proFilePath == m_proFilePath) { return; }
-
+	if (proFilePath == "" || proFilePath == m_proFilePath) {return;}
+	
 	m_engine->unloadProfile();
 	m_proFilePath = proFilePath;
 	m_dllFilePath = "";
 	m_dllFileName = "";
-
+	
 	lineDllPath->setText(m_proFilePath);
-	textEdit->addMessage("Plugin path changed for " + m_proFilePath, Qt::black);
+	textEdit->addMessage("Plugin path changed for " + m_proFilePath,Qt::black);
 	this->setState(HmiState::ReadyToPlayNotLoaded);
 }
 
@@ -295,9 +297,9 @@ void MainWindow::slotSettings()
 	SettingsDialog settingsDialog(this);
 	settingsDialog.addSettingsWidget(new GeneralSettingsWidget(&settingsDialog));
 	settingsDialog.addSettingsWidget(new VJoySettingsWidget(&settingsDialog));
-
+	
 	int result = settingsDialog.exec();
-	if(result == QDialog::Rejected) { return; }
+	if (result == QDialog::Rejected) {return;}
 }
 
 // SLOT COMPILATION ///////////////////////////////////////////////////////////
@@ -310,43 +312,42 @@ void MainWindow::slotCompilation()
 // SLOT PLAY //////////////////////////////////////////////////////////////////
 void MainWindow::slotPlay()
 {
-	if(m_engine->isActive()) { return; }
-
+	if (m_engine->isActive()) {return;}
+	
 	// load the plugin only if necessary
 	bool bConfigOk = true;
-	if(m_dllFilePath == "" || !m_engine->isLoaded())
+	if (m_dllFilePath == "" || !m_engine->isLoaded())
 	{
 		// search for one dll
 		QString dllDir = dirName(m_proFilePath) + "/" + debugOrRelease();
-		QStringList dllFiles = QDir{ dllDir }.entryList({ "*.dll" }, QDir::Files);
-		if(dllFiles.size() == 0)
+		QStringList dllFiles = QDir{dllDir}.entryList({"*.dll"},QDir::Files);
+		if (dllFiles.size() == 0)
 		{
-			textEdit->addMessage("No profile dll in directory " + dllDir, Qt::red);
+			textEdit->addMessage("No profile dll in directory " + dllDir,Qt::red);
 			return;
 		}
-		else if(dllFiles.size() > 1)
+		else if (dllFiles.size() > 1)
 		{
-			textEdit->addMessage("Several profile dlls in directory " + dllDir, Qt::red);
+			textEdit->addMessage("Several profile dlls in directory " + dllDir,Qt::red);
 			return;
 		}
 		m_dllFileName = dllFiles[0];
 		m_dllFilePath = dllDir + "/" + m_dllFileName;
-
+		
 		// load the profile plugin
 		bConfigOk = m_engine->loadProfile(m_dllFilePath);
-		chkMappingRepeater->setEnabled(bConfigOk);
 	}
-
+	
 	// manages loading errors
-	if(!bConfigOk)
+	if (!bConfigOk)
 	{
 		this->setState(HmiState::ReadyToPlayNotLoaded);
 		return;
 	}
-
+	
 	// configuration and start
 	this->setState(HmiState::Playing);
-	if(!m_engine->run(boxRefreshRate->value())) { this->setState(HmiState::ReadyToPlayLoaded); }
+	if (!m_engine->run(boxRefreshRate->value())) {this->setState(HmiState::ReadyToPlayLoaded);}
 }
 
 // SLOT STOP //////////////////////////////////////////////////////////////////

--- a/UjpsMainApp/CODE/HMI/MainWindow.cpp
+++ b/UjpsMainApp/CODE/HMI/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include <QToolBar>
 #include <QLabel>
 #include <QSpinBox>
+#include <QCheckBox>
 #include <QThread>
 #include <QFileDialog>
 
@@ -47,43 +48,44 @@ MainWindow::MainWindow(QString proFilePath, int dtms, bool bPlay, QWidget *paren
 	settings.readFile();
 	bool bUseVJoyConfigBinary = settings.property("bUseVJoyConfigBinary").toBool();
 	QString vJoyConfigBinary = settings.property("vJoyConfigBinary").toString();
-	VirtualJoystick::setVJoyConfigOptions(bUseVJoyConfigBinary,vJoyConfigBinary);
-	
+	VirtualJoystick::setVJoyConfigOptions(bUseVJoyConfigBinary, vJoyConfigBinary);
+
 	// init
 	m_proFilePath = "";
 	m_dllFilePath = "";
 	m_dllFileName = "";
-	m_engine = new ProfileEngine{this};
-	
-	m_compilWidget = new CompilationWidget{this};
-	
+	m_engine = new ProfileEngine{ this };
+
+	m_compilWidget = new CompilationWidget{ this };
+
 	this->createActions();
 	this->setupWidget();
 	this->setState(HmiState::WaitingForDll);
-	
+
 	// connections
-	QObject::connect(m_engine,&ProfileEngine::message,textEdit,&TextEdit::addMessage);
-	QObject::connect(actionCompilation,&QAction::triggered,this,&MainWindow::slotCompilation);
-	QObject::connect(actionSettings,&QAction::triggered,this,&MainWindow::slotSettings);
-	QObject::connect(actionPlay,&QAction::triggered,this,&MainWindow::slotPlay);
-	QObject::connect(actionStop,&QAction::triggered,this,&MainWindow::slotStop);
-	QObject::connect(actionUnload,&QAction::triggered,this,&MainWindow::slotUnload);
-	QObject::connect(boutonBrowse,&QPushButton::clicked,this,&MainWindow::slotBrowseButtonClicked);
-	
+	QObject::connect(chkMappingRepeater, &QCheckBox::stateChanged, m_engine, &ProfileEngine::slotMappingRepeaterChanged);
+	QObject::connect(m_engine, &ProfileEngine::message, textEdit, &TextEdit::addMessage);
+	QObject::connect(actionCompilation, &QAction::triggered, this, &MainWindow::slotCompilation);
+	QObject::connect(actionSettings, &QAction::triggered, this, &MainWindow::slotSettings);
+	QObject::connect(actionPlay, &QAction::triggered, this, &MainWindow::slotPlay);
+	QObject::connect(actionStop, &QAction::triggered, this, &MainWindow::slotStop);
+	QObject::connect(actionUnload, &QAction::triggered, this, &MainWindow::slotUnload);
+	QObject::connect(boutonBrowse, &QPushButton::clicked, this, &MainWindow::slotBrowseButtonClicked);
+
 	// arguments supplémentaires
-	if (!proFilePath.isEmpty())
+	if(!proFilePath.isEmpty())
 	{
 		m_proFilePath = proFilePath;
 		m_dllFilePath = "";
 		m_dllFileName = "";
-		
+
 		lineDllPath->setText(m_proFilePath);
-		textEdit->addMessage("Plugin path changed for " + m_proFilePath,Qt::black);
+		textEdit->addMessage("Plugin path changed for " + m_proFilePath, Qt::black);
 		this->setState(HmiState::ReadyToPlayNotLoaded);
-		
+
 		boxRefreshRate->setValue(dtms);
-		
-		if (bPlay) {this->slotPlay();}
+
+		if(bPlay) { this->slotPlay(); }
 	}
 }
 
@@ -91,7 +93,7 @@ MainWindow::~MainWindow()
 {
 	// write settings
 	ApplicationSettings& settings = ApplicationSettings::instance();
-	if (!settings.isEmpty()) {settings.writeFile();}
+	if(!settings.isEmpty()) { settings.writeFile(); }
 }
 
 
@@ -101,23 +103,23 @@ MainWindow::~MainWindow()
 // CREATE ACTIONS /////////////////////////////////////////////////////////////
 void MainWindow::createActions()
 {
-	actionSettings = new QAction("Settings",this);
+	actionSettings = new QAction("Settings", this);
 	actionSettings->setStatusTip("Application settings");
 	actionSettings->setIcon(QIcon(":/RESOURCES/ICONES/outils.png"));
-	
-	actionCompilation = new QAction("Compilation",this);
+
+	actionCompilation = new QAction("Compilation", this);
 	actionCompilation->setStatusTip("Compile profile");
 	actionCompilation->setIcon(QIcon(":/RESOURCES/ICONES/compilation.png"));
-	
-	actionPlay = new QAction("Run",this);
+
+	actionPlay = new QAction("Run", this);
 	actionPlay->setStatusTip("Load and run profile");
 	actionPlay->setIcon(QIcon(":/RESOURCES/ICONES/play.png"));
-	
-	actionStop = new QAction("Stop",this);
+
+	actionStop = new QAction("Stop", this);
 	actionStop->setStatusTip("Stop profile");
 	actionStop->setIcon(QIcon(":/RESOURCES/ICONES/stop.png"));
-	
-	actionUnload = new QAction("Unload",this);
+
+	actionUnload = new QAction("Unload", this);
 	actionUnload->setStatusTip("Unload profile");
 	actionUnload->setIcon(QIcon(":/RESOURCES/ICONES/eject.png"));
 }
@@ -130,9 +132,9 @@ void MainWindow::setupWidget()
 	this->setLayout(layout);
 	layoutDllChoice = new QHBoxLayout(this);
 	layoutRefreshRate = new QHBoxLayout(this);
-	
+
 	// toolbar
-	toolbar = new QToolBar("Session",this);
+	toolbar = new QToolBar("Session", this);
 	toolbar->setFloatable(false);
 	toolbar->setMovable(false);
 	toolbar->addAction(actionSettings);
@@ -140,47 +142,54 @@ void MainWindow::setupWidget()
 	toolbar->addAction(actionPlay);
 	toolbar->addAction(actionStop);
 	toolbar->addAction(actionUnload);
-	
+
 	// dll choice
-	boutonBrowse = new QPushButton("Browse",this);
+	boutonBrowse = new QPushButton("Browse", this);
 	lineDllPath = new QLineEdit(this);
 	lineDllPath->setReadOnly(true);
-	
+
 	// refresh rate
-	labelRefreshRate = new QLabel("Refresh rate:",this);
+	labelRefreshRate = new QLabel("Refresh rate:", this);
 	boxRefreshRate = new QSpinBox(this);
 	boxRefreshRate->setMinimum(5);
 	boxRefreshRate->setMaximum(500);
 	boxRefreshRate->setValue(15);
 	boxRefreshRate->setSingleStep(500);
 	boxRefreshRate->setSuffix(" ms");
-	
+
+	// mapping repeater
+	chkMappingRepeater = new QCheckBox("Mapping Repeater", this);
+	chkMappingRepeater->setChecked(Qt::CheckState::Unchecked);
+	chkMappingRepeater->setToolTip("Detected vJoy inputs are repeated for " + QString::number(g_MAPPING_REPEATER_DURATION) + " seconds, to help map actions in game without real joysticks interfering.");
+	chkMappingRepeater->setEnabled(false);
+
 	// text edit
 	textEdit = new TextEdit(this);
-	
+
 	// add widgets to laytouts
 	layoutDllChoice->addWidget(boutonBrowse);
 	layoutDllChoice->addWidget(lineDllPath);
 	layoutRefreshRate->addWidget(labelRefreshRate);
 	layoutRefreshRate->addWidget(boxRefreshRate);
+	layoutRefreshRate->addWidget(chkMappingRepeater);
 	layoutRefreshRate->addStretch();
-	
+
 	layout->addLayout(layoutDllChoice);
 	layout->addSpacing(5);
 	layout->addLayout(layoutRefreshRate);
 	layout->addSpacing(5);
 	layout->addWidget(toolbar);
 	layout->addWidget(textEdit);
-	
+
 	// end
-	this->resize(500,500);
+	this->resize(500, 500);
 	this->setWindowIcon(QIcon(":/RESOURCES/ICONES/gamepad.png"));
 }
 
 // SET STATE //////////////////////////////////////////////////////////////////
 void MainWindow::setState(HmiState s)
 {
-	if (s == HmiState::WaitingForDll)
+	if(s == HmiState::WaitingForDll)
 	{
 		actionSettings->setEnabled(true);
 		actionCompilation->setEnabled(false);
@@ -189,8 +198,10 @@ void MainWindow::setState(HmiState s)
 		actionUnload->setEnabled(false);
 		boutonBrowse->setEnabled(true);
 		boxRefreshRate->setEnabled(false);
+		chkMappingRepeater->setChecked(false);
+		chkMappingRepeater->setEnabled(false);
 	}
-	else if (s == HmiState::ReadyToPlayNotLoaded)
+	else if(s == HmiState::ReadyToPlayNotLoaded)
 	{
 		actionSettings->setEnabled(true);
 		actionCompilation->setEnabled(true);
@@ -199,8 +210,10 @@ void MainWindow::setState(HmiState s)
 		actionUnload->setEnabled(false);
 		boutonBrowse->setEnabled(true);
 		boxRefreshRate->setEnabled(true);
+		chkMappingRepeater->setChecked(false);
+		chkMappingRepeater->setEnabled(false);
 	}
-	else if (s == HmiState::ReadyToPlayLoaded)
+	else if(s == HmiState::ReadyToPlayLoaded)
 	{
 		actionSettings->setEnabled(false);
 		actionCompilation->setEnabled(false);
@@ -209,8 +222,10 @@ void MainWindow::setState(HmiState s)
 		actionUnload->setEnabled(true);
 		boutonBrowse->setEnabled(true);
 		boxRefreshRate->setEnabled(true);
+		chkMappingRepeater->setChecked(false);
+		chkMappingRepeater->setEnabled(false);
 	}
-	else if (s == HmiState::Playing)
+	else if(s == HmiState::Playing)
 	{
 		actionSettings->setEnabled(false);
 		actionCompilation->setEnabled(false);
@@ -219,8 +234,9 @@ void MainWindow::setState(HmiState s)
 		actionUnload->setEnabled(false);
 		boutonBrowse->setEnabled(false);
 		boxRefreshRate->setEnabled(false);
+		chkMappingRepeater->setEnabled(true);
 	}
-	else if (s == HmiState::Quitting)
+	else if(s == HmiState::Quitting)
 	{
 		actionSettings->setEnabled(false);
 		actionCompilation->setEnabled(false);
@@ -229,26 +245,25 @@ void MainWindow::setState(HmiState s)
 		actionUnload->setEnabled(false);
 		boutonBrowse->setEnabled(false);
 		boxRefreshRate->setEnabled(false);
+		chkMappingRepeater->setEnabled(false);
 	}
 }
 
 // CLOSE EVENT ////////////////////////////////////////////////////////////////
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-	textEdit->addMessage("Closing",Qt::black);
+	textEdit->addMessage("Closing", Qt::black);
 	m_engine->stop();
 	this->setState(HmiState::Quitting);
-	
-	if (m_engine->isLoaded())
+
+	if(m_engine->isLoaded())
 	{
 		m_engine->unloadProfile();
 		QThread::sleep(1);
 	}
-	
+
 	event->accept();
 }
-
-
 
 
 
@@ -262,15 +277,15 @@ void MainWindow::closeEvent(QCloseEvent *event)
 void MainWindow::slotBrowseButtonClicked()
 {
 	QString proFilePath = MyFileDialog::getOpenFileName(this, "Select profile plugin", "defaultDirectory", "*.pro");
-	if (proFilePath == "" || proFilePath == m_proFilePath) {return;}
-	
+	if(proFilePath == "" || proFilePath == m_proFilePath) { return; }
+
 	m_engine->unloadProfile();
 	m_proFilePath = proFilePath;
 	m_dllFilePath = "";
 	m_dllFileName = "";
-	
+
 	lineDllPath->setText(m_proFilePath);
-	textEdit->addMessage("Plugin path changed for " + m_proFilePath,Qt::black);
+	textEdit->addMessage("Plugin path changed for " + m_proFilePath, Qt::black);
 	this->setState(HmiState::ReadyToPlayNotLoaded);
 }
 
@@ -280,9 +295,9 @@ void MainWindow::slotSettings()
 	SettingsDialog settingsDialog(this);
 	settingsDialog.addSettingsWidget(new GeneralSettingsWidget(&settingsDialog));
 	settingsDialog.addSettingsWidget(new VJoySettingsWidget(&settingsDialog));
-	
+
 	int result = settingsDialog.exec();
-	if (result == QDialog::Rejected) {return;}
+	if(result == QDialog::Rejected) { return; }
 }
 
 // SLOT COMPILATION ///////////////////////////////////////////////////////////
@@ -295,42 +310,43 @@ void MainWindow::slotCompilation()
 // SLOT PLAY //////////////////////////////////////////////////////////////////
 void MainWindow::slotPlay()
 {
-	if (m_engine->isActive()) {return;}
-	
+	if(m_engine->isActive()) { return; }
+
 	// load the plugin only if necessary
 	bool bConfigOk = true;
-	if (m_dllFilePath == "" || !m_engine->isLoaded())
+	if(m_dllFilePath == "" || !m_engine->isLoaded())
 	{
 		// search for one dll
 		QString dllDir = dirName(m_proFilePath) + "/" + debugOrRelease();
-		QStringList dllFiles = QDir{dllDir}.entryList({"*.dll"},QDir::Files);
-		if (dllFiles.size() == 0)
+		QStringList dllFiles = QDir{ dllDir }.entryList({ "*.dll" }, QDir::Files);
+		if(dllFiles.size() == 0)
 		{
-			textEdit->addMessage("No profile dll in directory " + dllDir,Qt::red);
+			textEdit->addMessage("No profile dll in directory " + dllDir, Qt::red);
 			return;
 		}
-		else if (dllFiles.size() > 1)
+		else if(dllFiles.size() > 1)
 		{
-			textEdit->addMessage("Several profile dlls in directory " + dllDir,Qt::red);
+			textEdit->addMessage("Several profile dlls in directory " + dllDir, Qt::red);
 			return;
 		}
 		m_dllFileName = dllFiles[0];
 		m_dllFilePath = dllDir + "/" + m_dllFileName;
-		
+
 		// load the profile plugin
 		bConfigOk = m_engine->loadProfile(m_dllFilePath);
+		chkMappingRepeater->setEnabled(bConfigOk);
 	}
-	
+
 	// manages loading errors
-	if (!bConfigOk)
+	if(!bConfigOk)
 	{
 		this->setState(HmiState::ReadyToPlayNotLoaded);
 		return;
 	}
-	
+
 	// configuration and start
 	this->setState(HmiState::Playing);
-	if (!m_engine->run(boxRefreshRate->value())) {this->setState(HmiState::ReadyToPlayLoaded);}
+	if(!m_engine->run(boxRefreshRate->value())) { this->setState(HmiState::ReadyToPlayLoaded); }
 }
 
 // SLOT STOP //////////////////////////////////////////////////////////////////

--- a/UjpsMainApp/CODE/HMI/MainWindow.h
+++ b/UjpsMainApp/CODE/HMI/MainWindow.h
@@ -13,6 +13,7 @@ class QLineEdit;
 class QToolBar;
 class QLabel;
 class QSpinBox;
+class QCheckBox;
 
 class CompilationWidget;
 class ProfileEngine;
@@ -71,6 +72,7 @@ class MainWindow : public QWidget
 		QToolBar *toolbar;
 		QLabel *labelRefreshRate;
 		QSpinBox *boxRefreshRate;
+		QCheckBox *chkMappingRepeater;
 		
 		QString m_proFilePath;
 		QString m_dllFilePath;

--- a/UjpsMainApp/CODE/ProfileEngine.cpp
+++ b/UjpsMainApp/CODE/ProfileEngine.cpp
@@ -152,3 +152,9 @@ void ProfileEngine::slotOneLoop()
 	catch (std::exception &e) {emit message(e.what(),Qt::red);}
 }
 
+void ProfileEngine::slotMappingRepeaterChanged(int state)
+{
+	if(m_profile)
+		m_profile->setMappingRepeater(state == Qt::Checked);
+}
+

--- a/UjpsMainApp/CODE/ProfileEngine.h
+++ b/UjpsMainApp/CODE/ProfileEngine.h
@@ -32,6 +32,9 @@ class ProfileEngine : public QObject
 		
 	private slots:
 		void slotOneLoop();
+
+	public slots:
+		void slotMappingRepeaterChanged(int state);
 		
 		
 	signals:


### PR DESCRIPTION
When enabled (via checkbox on GUI), detected vJoy inputs are repeated for a short duration of time to help map actions in game without physical joysticks interfering.

This is a similar feature found in Joystick Gremlin.

Besides using the GUI, AbstractProfile can set whether 'mapping repeater' is enabled, which gives the flexibility to be turned on and off procedurally by the user profile if they desire.